### PR TITLE
Add Curse of Strahd toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It also reports the chance of hitting at least once across multiple attacks.
 - Critical hit range support
 - Chance to hit at least once across several attacks
 - Simple Flask web interface
+- Ability score roller (4d6 drop lowest)
+- Random Tarokka card draw for Curse of Strahd
+- Barovian encounter generator
+- Random NPC name generator
 
 ## Getting Started
 Install dependencies and run the development server:

--- a/app.py
+++ b/app.py
@@ -1,5 +1,11 @@
 from flask import Flask, render_template, request
 from dpr import Attack, compute_dpr, chance_to_hit_at_least_once
+from tools import (
+    generate_ability_scores,
+    random_barovia_encounter,
+    random_name,
+    random_tarokka_card,
+)
 
 app = Flask(__name__)
 
@@ -31,6 +37,30 @@ def index():
         result = compute_dpr(attack)
         chance = chance_to_hit_at_least_once(attack)
     return render_template('index.html', result=result, chance=chance)
+
+
+@app.route('/ability-scores')
+def ability_scores():
+    scores = generate_ability_scores()
+    return render_template('ability_scores.html', scores=scores)
+
+
+@app.route('/tarokka')
+def tarokka():
+    card = random_tarokka_card()
+    return render_template('tarokka.html', card=card)
+
+
+@app.route('/encounter')
+def encounter():
+    encounter = random_barovia_encounter()
+    return render_template('encounter.html', encounter=encounter)
+
+
+@app.route('/npc-name')
+def npc_name():
+    name = random_name()
+    return render_template('npc_name.html', name=name)
 
 
 if __name__ == '__main__':

--- a/templates/ability_scores.html
+++ b/templates/ability_scores.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Ability Scores</title>
+</head>
+<body>
+<h1>Random Ability Scores</h1>
+<p>{{ scores | join(', ') }}</p>
+<a href="{{ url_for('ability_scores') }}">Roll again</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Random Encounter</title>
+</head>
+<body>
+<h1>Barovian Encounter</h1>
+<p>{{ encounter }}</p>
+<a href="{{ url_for('encounter') }}">Another encounter</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,12 @@
 </head>
 <body>
 <h1>D&D DPR Calculator</h1>
+<nav>
+    <a href="{{ url_for('ability_scores') }}">Ability Scores</a> |
+    <a href="{{ url_for('tarokka') }}">Tarokka Card</a> |
+    <a href="{{ url_for('encounter') }}">Encounter</a> |
+    <a href="{{ url_for('npc_name') }}">NPC Name</a>
+</nav>
 <form method="post">
     <label>Attack bonus: <input type="number" name="attack_bonus" required></label><br>
     <label>Target AC: <input type="number" name="target_ac" required></label><br>

--- a/templates/npc_name.html
+++ b/templates/npc_name.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>NPC Name</title>
+</head>
+<body>
+<h1>Random NPC Name</h1>
+<p>{{ name }}</p>
+<a href="{{ url_for('npc_name') }}">Generate again</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/templates/tarokka.html
+++ b/templates/tarokka.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tarokka Card</title>
+</head>
+<body>
+<h1>Tarokka Card</h1>
+<p>{{ card }}</p>
+<a href="{{ url_for('tarokka') }}">Draw again</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/test_tools.py
+++ b/test_tools.py
@@ -1,0 +1,22 @@
+import tools
+
+
+def test_generate_ability_scores():
+    scores = tools.generate_ability_scores()
+    assert len(scores) == 6
+    assert all(3 <= s <= 18 for s in scores)
+
+
+def test_random_tarokka_card():
+    card = tools.random_tarokka_card()
+    assert card in tools.TAROKKA_CARDS
+
+
+def test_random_barovia_encounter():
+    enc = tools.random_barovia_encounter()
+    assert enc in tools.BAROVIA_ENCOUNTERS
+
+
+def test_random_name():
+    name = tools.random_name()
+    assert name in tools.BAROVIAN_NAMES + tools.GENERIC_NAMES

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,65 @@
+import random
+
+# Lists of items for Curse of Strahd and general D&D tools
+TAROKKA_CARDS = [
+    "The Artifact",
+    "The Beast",
+    "The Broken One",
+    "The Darklord",
+    "The Donjon",
+    "The Horseman",
+    "The Innocent",
+    "The Marionette",
+    "The Mists",
+    "The Raven",
+]
+
+BAROVIA_ENCOUNTERS = [
+    "Howling wolves surround the party",
+    "Strahd's carriage appears in the distance",
+    "A murder of crows follows you for a mile",
+    "You find a wandering Vistani camp",
+    "Ghostly villagers emerge from the fog",
+]
+
+BAROVIAN_NAMES = [
+    "Ireena Kolyana",
+    "Ismark Kolyanovich",
+    "Madam Eva",
+    "Viktor Vallakovich",
+    "Rictavio",
+    "Ezmerelda d'Avenir",
+]
+
+GENERIC_NAMES = [
+    "Alaric",
+    "Seraphina",
+    "Thorin",
+    "Lyra",
+    "Gideon",
+    "Mira",
+]
+
+
+def generate_ability_scores() -> list[int]:
+    """Roll 4d6 drop lowest for six ability scores."""
+    def roll() -> int:
+        rolls = [random.randint(1, 6) for _ in range(4)]
+        return sum(sorted(rolls)[1:])
+
+    return [roll() for _ in range(6)]
+
+
+def random_tarokka_card() -> str:
+    """Return a random Tarokka card."""
+    return random.choice(TAROKKA_CARDS)
+
+
+def random_barovia_encounter() -> str:
+    """Return a random encounter in Barovia."""
+    return random.choice(BAROVIA_ENCOUNTERS)
+
+
+def random_name() -> str:
+    """Return a random name, drawing from Barovian and generic lists."""
+    return random.choice(BAROVIAN_NAMES + GENERIC_NAMES)


### PR DESCRIPTION
## Summary
- add ability score roller
- include Tarokka card draw and Barovian encounter generator
- provide random NPC names and navigation links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a449ec346883228105bf8421293812