### PR TITLE
Add session notes and puzzle tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+notes.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ It also reports the chance of hitting at least once across multiple attacks.
 - Critical hit range support
 - Chance to hit at least once across several attacks
 - Simple Flask web interface
-- Session notes that persist to disk
+- Ability score roller (4d6 drop lowest)
+- Random Tarokka card draw for Curse of Strahd
+- Barovian encounter generator
+- Random NPC name generator
+- Session-based notes that persist to disk
 - Prime factorization puzzle tool
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # D&D DPR Calculator
 
-A small web application for computing expected damage per round (DPR) for Dungeons & Dragons 5e attacks.  
+A small web application for computing expected damage per round (DPR) for Dungeons & Dragons 5e attacks.
 It also reports the chance of hitting at least once across multiple attacks.
 
 ## Features
@@ -8,6 +8,8 @@ It also reports the chance of hitting at least once across multiple attacks.
 - Critical hit range support
 - Chance to hit at least once across several attacks
 - Simple Flask web interface
+- Session notes that persist to disk
+- Prime factorization puzzle tool
 
 ## Getting Started
 Install dependencies and run the development server:

--- a/app.py
+++ b/app.py
@@ -1,7 +1,28 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, redirect, url_for
 from dpr import Attack, compute_dpr, chance_to_hit_at_least_once
+from puzzles import prime_factors
+import json
+import os
+from datetime import datetime
 
 app = Flask(__name__)
+
+NOTES_FILE = os.path.join(os.path.dirname(__file__), 'notes.json')
+
+
+def load_notes():
+    if not os.path.exists(NOTES_FILE):
+        return []
+    with open(NOTES_FILE, 'r') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return []
+
+
+def save_notes(notes):
+    with open(NOTES_FILE, 'w') as f:
+        json.dump(notes, f, indent=2)
 
 
 @app.route('/', methods=['GET', 'POST'])
@@ -31,6 +52,31 @@ def index():
         result = compute_dpr(attack)
         chance = chance_to_hit_at_least_once(attack)
     return render_template('index.html', result=result, chance=chance)
+
+
+@app.route('/notes', methods=['GET', 'POST'])
+def notes():
+    notes = load_notes()
+    if request.method == 'POST':
+        content = request.form.get('content', '').strip()
+        if content:
+            notes.append({'time': datetime.utcnow().isoformat(), 'content': content})
+            save_notes(notes)
+        return redirect(url_for('notes'))
+    return render_template('notes.html', notes=notes)
+
+
+@app.route('/puzzles', methods=['GET', 'POST'])
+def puzzles():
+    factors = None
+    if request.method == 'POST':
+        try:
+            number = int(request.form.get('number', '0'))
+            if number > 1:
+                factors = prime_factors(number)
+        except ValueError:
+            factors = []
+    return render_template('puzzles.html', factors=factors)
 
 
 if __name__ == '__main__':

--- a/puzzles.py
+++ b/puzzles.py
@@ -1,0 +1,15 @@
+from typing import List
+
+
+def prime_factors(n: int) -> List[int]:
+    """Return the prime factors of n."""
+    factors: List[int] = []
+    d = 2
+    while d * d <= n:
+        while n % d == 0:
+            factors.append(d)
+            n //= d
+        d += 1
+    if n > 1:
+        factors.append(n)
+    return factors

--- a/templates/ability_scores.html
+++ b/templates/ability_scores.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Ability Scores</title>
+</head>
+<body>
+<h1>Random Ability Scores</h1>
+<p>{{ scores | join(', ') }}</p>
+<a href="{{ url_for('ability_scores') }}">Roll again</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Random Encounter</title>
+</head>
+<body>
+<h1>Barovian Encounter</h1>
+<p>{{ encounter }}</p>
+<a href="{{ url_for('encounter') }}">Another encounter</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,14 @@
 </head>
 <body>
 <h1>D&D DPR Calculator</h1>
+<nav>
+    <a href="{{ url_for('notes') }}">Session Notes</a> |
+    <a href="{{ url_for('puzzles') }}">Puzzle Tools</a> |
+    <a href="{{ url_for('ability_scores') }}">Ability Scores</a> |
+    <a href="{{ url_for('tarokka') }}">Tarokka Card</a> |
+    <a href="{{ url_for('encounter') }}">Encounter</a> |
+    <a href="{{ url_for('npc_name') }}">NPC Name</a>
+</nav>
 <form method="post">
     <label>Attack bonus: <input type="number" name="attack_bonus" required></label><br>
     <label>Target AC: <input type="number" name="target_ac" required></label><br>

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -7,14 +7,18 @@
 <body>
 <h1>Session Notes</h1>
 <form method="post">
+    <input type="text" name="session" placeholder="Session name"><br>
     <textarea name="content" rows="4" cols="50" placeholder="Write a note..."></textarea><br>
     <button type="submit">Add Note</button>
 </form>
+{% for session, notes in grouped_notes.items() %}
+<h2>{{ session }}</h2>
 <ul>
-{% for note in notes %}
+    {% for note in notes %}
     <li><strong>{{ note.time }}:</strong> {{ note.content }}</li>
-{% endfor %}
+    {% endfor %}
 </ul>
-<a href="/">Back to calculator</a>
+{% endfor %}
+<a href="{{ url_for('index') }}">Back</a>
 </body>
 </html>

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Session Notes</title>
+</head>
+<body>
+<h1>Session Notes</h1>
+<form method="post">
+    <textarea name="content" rows="4" cols="50" placeholder="Write a note..."></textarea><br>
+    <button type="submit">Add Note</button>
+</form>
+<ul>
+{% for note in notes %}
+    <li><strong>{{ note.time }}:</strong> {{ note.content }}</li>
+{% endfor %}
+</ul>
+<a href="/">Back to calculator</a>
+</body>
+</html>

--- a/templates/npc_name.html
+++ b/templates/npc_name.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>NPC Name</title>
+</head>
+<body>
+<h1>Random NPC Name</h1>
+<p>{{ name }}</p>
+<a href="{{ url_for('npc_name') }}">Generate again</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/templates/puzzles.html
+++ b/templates/puzzles.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Puzzle Tools</title>
+</head>
+<body>
+<h1>Prime Factorization</h1>
+<form method="post">
+    <label>Number: <input type="number" name="number" min="2"></label>
+    <button type="submit">Factor</button>
+</form>
+{% if factors is not none %}
+<p>Factors: {{ factors|join(', ') if factors else 'Invalid input' }}</p>
+{% endif %}
+<a href="/">Back to calculator</a>
+</body>
+</html>

--- a/templates/tarokka.html
+++ b/templates/tarokka.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tarokka Card</title>
+</head>
+<body>
+<h1>Tarokka Card</h1>
+<p>{{ card }}</p>
+<a href="{{ url_for('tarokka') }}">Draw again</a> |
+<a href="{{ url_for('index') }}">Back</a>
+</body>
+</html>

--- a/test_puzzles.py
+++ b/test_puzzles.py
@@ -1,0 +1,6 @@
+from puzzles import prime_factors
+
+
+def test_prime_factors():
+    assert prime_factors(28) == [2, 2, 7]
+    assert prime_factors(29) == [29]

--- a/test_tools.py
+++ b/test_tools.py
@@ -1,0 +1,22 @@
+import tools
+
+
+def test_generate_ability_scores():
+    scores = tools.generate_ability_scores()
+    assert len(scores) == 6
+    assert all(3 <= s <= 18 for s in scores)
+
+
+def test_random_tarokka_card():
+    card = tools.random_tarokka_card()
+    assert card in tools.TAROKKA_CARDS
+
+
+def test_random_barovia_encounter():
+    enc = tools.random_barovia_encounter()
+    assert enc in tools.BAROVIA_ENCOUNTERS
+
+
+def test_random_name():
+    name = tools.random_name()
+    assert name in tools.BAROVIAN_NAMES + tools.GENERIC_NAMES

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,65 @@
+import random
+
+# Lists of items for Curse of Strahd and general D&D tools
+TAROKKA_CARDS = [
+    "The Artifact",
+    "The Beast",
+    "The Broken One",
+    "The Darklord",
+    "The Donjon",
+    "The Horseman",
+    "The Innocent",
+    "The Marionette",
+    "The Mists",
+    "The Raven",
+]
+
+BAROVIA_ENCOUNTERS = [
+    "Howling wolves surround the party",
+    "Strahd's carriage appears in the distance",
+    "A murder of crows follows you for a mile",
+    "You find a wandering Vistani camp",
+    "Ghostly villagers emerge from the fog",
+]
+
+BAROVIAN_NAMES = [
+    "Ireena Kolyana",
+    "Ismark Kolyanovich",
+    "Madam Eva",
+    "Viktor Vallakovich",
+    "Rictavio",
+    "Ezmerelda d'Avenir",
+]
+
+GENERIC_NAMES = [
+    "Alaric",
+    "Seraphina",
+    "Thorin",
+    "Lyra",
+    "Gideon",
+    "Mira",
+]
+
+
+def generate_ability_scores() -> list[int]:
+    """Roll 4d6 drop lowest for six ability scores."""
+    def roll() -> int:
+        rolls = [random.randint(1, 6) for _ in range(4)]
+        return sum(sorted(rolls)[1:])
+
+    return [roll() for _ in range(6)]
+
+
+def random_tarokka_card() -> str:
+    """Return a random Tarokka card."""
+    return random.choice(TAROKKA_CARDS)
+
+
+def random_barovia_encounter() -> str:
+    """Return a random encounter in Barovia."""
+    return random.choice(BAROVIA_ENCOUNTERS)
+
+
+def random_name() -> str:
+    """Return a random name, drawing from Barovian and generic lists."""
+    return random.choice(BAROVIAN_NAMES + GENERIC_NAMES)


### PR DESCRIPTION
## Summary
- allow creating persistent session notes
- add prime factorization puzzle utility
- document new features and ignore runtime notes file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44ac24f7483229ec8ba5417e0bb83